### PR TITLE
Add dump option for workloads

### DIFF
--- a/praxis/backend/zigzag.py
+++ b/praxis/backend/zigzag.py
@@ -1,6 +1,7 @@
 import importlib.resources
 import logging
 import pickle
+import yaml
 from xdsl.dialects.transform import TileOp
 from typing import IO, Any, cast
 from xdsl.dialects.builtin import IntegerType, ModuleOp, ShapedType, ContainerType
@@ -237,6 +238,21 @@ def praxis_zigzag_wrapper(
     cmes = cast(list[tuple[CostModelEvaluation, Any]], cmes[0][1])
 
     return cmes
+
+def dump_zigzag_workload(
+    module: ModuleOp,
+    output: IO,
+    ) -> None:
+    for op in module.body.walk():
+        if isinstance(op, GenericOp):
+            generic_op = op
+            if len(generic_op.outputs) != 1:
+                return
+            if not isinstance(generic_op.outputs[0].type, ShapedType):
+                return
+            # generate zigzag workload
+            workload = generate_zigzag_workload(generic_op)
+            yaml.dump(workload, output)
 
 
 def get_zigzag_cme(

--- a/praxis/tools/praxis_main.py
+++ b/praxis/tools/praxis_main.py
@@ -6,7 +6,7 @@ from xdsl.dialects.builtin import ModuleOp
 from snaxc.tools.snax_opt_main import SNAXOptMain
 
 from praxis.transforms import get_all_passes
-from praxis.backend.zigzag import get_zigzag_cme
+from praxis.backend.zigzag import dump_zigzag_workload, get_zigzag_cme
 
 
 class PraxisMain(SNAXOptMain):
@@ -67,6 +67,9 @@ class PraxisMain(SNAXOptMain):
         This version is adapted to, upon -t zigzag:
         - write to a binary stream
         - call zigzag with cli arguments (not typically done for targets)"
+        And to, upon -t zigzag-workload
+        - write to a yaml string stream
+        - call the backend function to convert workloads to a yaml file"
         """
         if self.args.target not in self.available_targets:
             raise Exception(f"Unknown target {self.args.target}")
@@ -82,7 +85,13 @@ class PraxisMain(SNAXOptMain):
             )
         else:
             output = StringIO()
-            self.available_targets[self.args.target](prog, output)
+            if self.args.target == "zigzag-workload":
+                dump_zigzag_workload(
+                    prog,
+                    output,
+                )
+            else:
+                self.available_targets[self.args.target](prog, output)
         return output.getvalue()
 
     def register_all_targets(self):
@@ -91,6 +100,7 @@ class PraxisMain(SNAXOptMain):
         function can not call a target function with arguments"""
         super().register_all_targets()
         self.available_targets["zigzag"] = lambda prog, output: None
+        self.available_targets["zigzag-workload"] = lambda prog, output: None
 
 
 def main():


### PR DESCRIPTION
This option dumps workloads.
I did not implement a test for this.

usage
```
(praxis) ❯ praxis-opt kernels/streamer_matmul/quantized_matmul_16_16_16.mlir -p preprocess -t zigzag-workload 
```
output result
```
- dimension_relations: []
  equation: O[d0][d1]+=I[d0][d2]*W[d2][d1]
  id: 0
  loop_dims:
  - D0
  - D1
  - D2
  loop_sizes:
  - 16
  - 16
  - 16
  operand_precision:
    I: 8
    O: 32
    O_final: 32
    W: 8
  operand_source:
    I: 0
    W: 0
  operator_type: Gemm
 
 
```