### PR TITLE
fix output final width in generated workloads

### DIFF
--- a/praxis/backend/zigzag.py
+++ b/praxis/backend/zigzag.py
@@ -112,7 +112,7 @@ def generate_zigzag_workload(generic_op: GenericOp):
 
     zigzag_description["operand_precision"] = dict()
     zigzag_description["operand_precision"]["O"] = widths[-1]
-    zigzag_description["operand_precision"]["O_final"] = widths[-1]
+    zigzag_description["operand_precision"]["O_final"] = widths[0]
     zigzag_description["operand_precision"]["W"] = widths[0]
     zigzag_description["operand_precision"]["I"] = widths[1]
 


### PR DESCRIPTION
Currently, the O_final width in the generated workload yaml file is 32, modify it to the correct 8.